### PR TITLE
Output time zone on all events

### DIFF
--- a/service/src/InstructorIQ.WebApplication/Controllers/EventController.cs
+++ b/service/src/InstructorIQ.WebApplication/Controllers/EventController.cs
@@ -60,10 +60,10 @@ namespace InstructorIQ.WebApplication.Controllers
                 calendarEvent.Categories.Add("Training");
 
                 if (e.Start.HasValue)
-                    calendarEvent.Start = new CalDateTime(e.Start.Value.UtcDateTime);
+                    calendarEvent.Start = new CalDateTime(e.Start.Value.UtcDateTime) { HasTime = true };
 
                 if (e.End.HasValue)
-                    calendarEvent.End = new CalDateTime(e.End.Value.UtcDateTime);
+                    calendarEvent.End = new CalDateTime(e.End.Value.UtcDateTime) { HasTime = true };
 
                 calendarEvent.LastModified = new CalDateTime(e.Modified.UtcDateTime);
 


### PR DESCRIPTION
I noticed that some events (occurring at midnight UTC) are being output without a time / timezone. 
`DTSTART;VALUE=DATE:20200320`
This is causing them to be interpreted by clients incorrectly, occurring at midnight instead of being displayed in the correct local timezone.
Related to: https://github.com/rianjs/ical.net/issues/77